### PR TITLE
fix: Remove deprecated `bottle :unneeded`

### DIFF
--- a/Formula/katafygio.rb
+++ b/Formula/katafygio.rb
@@ -4,7 +4,6 @@ class Katafygio < Formula
   homepage "https://github.com/bpineau/katafygio"
   version "0.8.3"
   license "MIT"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/bpineau/katafygio/releases/download/v0.8.3/katafygio_0.8.3_darwin_amd64.tar.gz"


### PR DESCRIPTION
Remove `bottle :unneeded` from brew formula

`bottle :unneeded` now provokes a warning from Homebrew:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
```

Homebrew apparently deprecated `bottle :unneeded` in Homebrew/brew@f65d525